### PR TITLE
Remove unrecognized Next.js option

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,6 @@ const nextConfig = {
   },
   experimental: {
     optimizeCss: true,
-    legacyBrowsers: false, // ✅ move here
   },
   reactStrictMode: true,
   compress: true, // ✅ Gzip compression


### PR DESCRIPTION
## Summary
- fix next configuration by removing the unsupported `legacyBrowsers` option

## Testing
- `npm run lint` *(fails: unknown env config `http-proxy`; ESLint errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_686b996bef6c832a8df01818cdff0f51