### PR TITLE
Replace dynamic imports in page

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import dynamic from 'next/dynamic';
 import Header from './components/Header';
 import Hero from './components/Hero';
 import Products from './components/Products';
-const Features = dynamic(() => import('./components/Features'));
-const FAQ = dynamic(() => import('./components/FAQ'));
-const Contact = dynamic(() => import('./components/Contact'));
-const Footer = dynamic(() => import('./components/Footer'));
-const New = dynamic(() => import('./components/New'));
+import Features from './components/Features';
+import FAQ from './components/FAQ';
+import Contact from './components/Contact';
+import Footer from './components/Footer';
+import New from './components/New';
 
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- change `dynamic` to direct imports in `src/app/page.js`

## Testing
- `npm run lint` *(fails: parser errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b996e93ec832aa81c24e8a0cb19c1